### PR TITLE
Update Monitor.TimedScript.PowerShell.FileAge.mpx

### DIFF
--- a/Monitor.TimedScript.PowerShell.FileAge.mpx
+++ b/Monitor.TimedScript.PowerShell.FileAge.mpx
@@ -336,12 +336,12 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 					<OnDemandDetections>
 						<OnDemandDetection MonitorTypeStateID="GoodCondition">
 							<Node ID="GoodConditionFilter">
-								<Node ID="DS" />
+								<Node ID="PA" />
 							</Node>
 						</OnDemandDetection>
 						<OnDemandDetection MonitorTypeStateID="BadCondition">
 							<Node ID="BadConditionFilter">
-								<Node ID="DS" />
+								<Node ID="PA" />
 							</Node>
 						</OnDemandDetection>
 					</OnDemandDetections>


### PR DESCRIPTION
On demand detections are using the composite data source which includes a scheduler. This should just be using the probe action ("PA" rather than "DS").